### PR TITLE
feat: import KLE layout from URL hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "astro": "6.4.4",
     "fluent-vue": "3.8.2",
     "jszip": "3.10.1",
+    "lz-string": "1.5.0",
     "nanotar": "0.3.0",
     "pinia": "3.0.4",
     "tailwindcss": "4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       jszip:
         specifier: 3.10.1
         version: 3.10.1
+      lz-string:
+        specifier: 1.5.0
+        version: 1.5.0
       nanotar:
         specifier: 0.3.0
         version: 0.3.0
@@ -2825,6 +2828,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-regexp@0.10.0:
     resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
@@ -7298,6 +7305,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-regexp@0.10.0:
     dependencies:

--- a/src/components/editor/utils/urlImport.test.ts
+++ b/src/components/editor/utils/urlImport.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import LZString from 'lz-string';
+import { extractLayoutFromHash, clearLayoutHash } from './urlImport';
+
+/** Set a fake `window` with the given hash for the duration of a test. */
+function stubWindow(hash: string) {
+  const win = {
+    location: { hash, href: `https://shield-wizard.genteure.com/${hash}` },
+    document: { title: 'test' },
+    history: { replaceState: vi.fn() },
+  };
+  vi.stubGlobal('window', win);
+  vi.stubGlobal('history', win.history);
+  vi.stubGlobal('document', win.document);
+  return win;
+}
+
+/** Encode a KLE array the same way kle-ng does. */
+function encodeKle(kleArray: unknown): string {
+  return LZString.compressToEncodedURIComponent(JSON.stringify(kleArray));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('extractLayoutFromHash', () => {
+  test('parses a #kle= payload into keys', () => {
+    // Two 1u keys side by side.
+    const payload = encodeKle([['', '']]);
+    stubWindow(`#kle=${payload}`);
+
+    const keys = extractLayoutFromHash();
+    expect(keys).not.toBeNull();
+    expect(keys!.length).toBe(2);
+    expect(keys![0].x).toBe(0);
+    expect(keys![1].x).toBe(1);
+    expect(keys!.every((k) => k.w === 1 && k.h === 1)).toBe(true);
+  });
+
+  test('returns null when there is no #kle= hash', () => {
+    stubWindow('#something-else');
+    expect(extractLayoutFromHash()).toBeNull();
+  });
+
+  test('returns null for an empty payload', () => {
+    stubWindow('#kle=');
+    expect(extractLayoutFromHash()).toBeNull();
+  });
+
+  test('returns null for an undecodable payload', () => {
+    stubWindow('#kle=not-valid-lz-data!!!');
+    expect(extractLayoutFromHash()).toBeNull();
+  });
+
+  test('returns null when window is undefined (SSR)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(extractLayoutFromHash()).toBeNull();
+  });
+});
+
+describe('clearLayoutHash', () => {
+  test('strips the #kle= hash via replaceState', () => {
+    const win = stubWindow('#kle=abc');
+    clearLayoutHash();
+    expect(win.history.replaceState).toHaveBeenCalledWith(
+      {},
+      'test',
+      'https://shield-wizard.genteure.com/',
+    );
+  });
+
+  test('does nothing when there is no #kle= hash', () => {
+    const win = stubWindow('#other');
+    clearLayoutHash();
+    expect(win.history.replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/utils/urlImport.ts
+++ b/src/components/editor/utils/urlImport.ts
@@ -1,0 +1,45 @@
+import LZString from 'lz-string';
+import type { Key } from '~/types';
+import { parseKleJson } from './layouthelper';
+
+/**
+ * Hash prefix used to pass a KLE layout into the wizard, e.g.
+ * `https://shield-wizard.genteure.com/#kle=<lz-compressed>`.
+ * The payload is `LZString.compressToEncodedURIComponent(JSON.stringify(kleArray))`,
+ * matching the encoding used by kle-ng (editor.keyboard-tools.xyz).
+ */
+const KLE_HASH_PREFIX = '#kle=';
+
+/** Guard against pathological payloads (mirrors kle-ng's 1 MB limit). */
+const MAX_DECOMPRESSED_SIZE = 1_000_000;
+
+/**
+ * Read a KLE layout from the current URL hash, if present.
+ * Returns the parsed keys, or null when there is no `#kle=` hash or the payload
+ * is empty/invalid.
+ */
+export function extractLayoutFromHash(): Key[] | null {
+  if (typeof window === 'undefined') return null;
+
+  const hash = window.location.hash;
+  if (!hash.startsWith(KLE_HASH_PREFIX)) return null;
+
+  const payload = hash.slice(KLE_HASH_PREFIX.length);
+  if (!payload) return null;
+
+  const json = LZString.decompressFromEncodedURIComponent(payload);
+  if (!json || json.length > MAX_DECOMPRESSED_SIZE) return null;
+
+  return parseKleJson(json);
+}
+
+/**
+ * Remove the `#kle=` hash from the URL without reloading, so a refresh or a
+ * later share doesn't re-import the incoming layout.
+ */
+export function clearLayoutHash(): void {
+  if (typeof window === 'undefined') return;
+  if (window.location.hash.startsWith(KLE_HASH_PREFIX)) {
+    history.replaceState({}, document.title, window.location.href.split('#')[0]);
+  }
+}

--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -7,12 +7,31 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from 'vue';
+import { onMounted, watch } from 'vue';
 import App from './app.vue';
 import { fluent, localeBundleMap, localeMap } from './locales';
-import { useNavigationStore } from './stores';
+import { useKeyboardStore, useNavigationStore } from './stores';
+import { extractLayoutFromHash, clearLayoutHash } from './editor/utils/urlImport';
 
 const nav = useNavigationStore();
+
+// Auto-import a KLE layout passed in the URL hash (e.g. from kle-ng via
+// `#kle=<lz-compressed>`), then show it on the Layout tab.
+onMounted(() => {
+  try {
+    const keys = extractLayoutFromHash();
+    if (keys && keys.length) {
+      const keyboard = useKeyboardStore();
+      keyboard.$patch({ layout: keys });
+      keyboard.sortLayout();
+      nav.activeTab = 'layout';
+    }
+  } catch (err) {
+    console.error('Failed to import layout from URL hash:', err);
+  } finally {
+    clearLayoutHash();
+  }
+});
 
 watch(
   () => nav.locale,


### PR DESCRIPTION
Auto-import a physical layout passed in the URL hash as `#kle=<lz-compressed>`, matching the encoding used by kle-ng (editor.keyboard-tools.xyz). On mount, the layout is decompressed, parsed via the existing parseKleJson, committed to the keyboard store, and shown on the Layout tab; the hash is then cleared.

- add lz-string dependency
- add urlImport util (extractLayoutFromHash / clearLayoutHash) with a 1 MB decompressed-size guard
- wire an onMounted auto-load hook in main.vue

This change would allow for better integration between https://editor.keyboard-tools.xyz/ and https://shield-wizard.genteure.workers.dev/ - changes on the kle-ng side are delivered to preview branch https://github.com/adamws/kle-ng/commit/aa04247df76114939288ddd850d6370c1eb5c3f6 and will be included in release if this pr accepted.

For test use kle-ng's preview deployment: https://kle-lvwbz2j4v-adams-projects-465f639f.vercel.app/
Create layout and use `Export->Open In Shield Wizard (ZMK)`
<img width="1175" height="412" alt="image" src="https://github.com/user-attachments/assets/7d09353e-4937-4403-b2ca-b1419e01b653" />
Then edit resulting url to point to local zmk-wizard dev instance or preview from this branch.